### PR TITLE
Add .scss as a default css file in sublime settings.

### DIFF
--- a/goto_css_declaration.sublime-settings
+++ b/goto_css_declaration.sublime-settings
@@ -1,3 +1,3 @@
 {
-    "css_files": [".css", ".sass", ".less"]
+    "css_files": [".css", ".scss", ".sass", ".less"]
 }


### PR DESCRIPTION
Hi, just thought it would be useful to put in .scss (for sass) as well for the defaults.

Cheers,
-Tak
